### PR TITLE
chore: usecompilecampaign wallet

### DIFF
--- a/src/hooks/useCompileCampaign/index.ts
+++ b/src/hooks/useCompileCampaign/index.ts
@@ -24,7 +24,7 @@ type IUseCompileCampaign = {
     concurrent?: number,
     tokenSplit?: number,
     overridStrategy?: UTXOStrategy,
-  ) => void;
+  ) => Promise<string>;
   quote: (
     planId: string,
     inputUnits: string[],


### PR DESCRIPTION
- compile return type is a promise type to help it work on minting interface